### PR TITLE
Created confirmation page

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -8,12 +8,11 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { useState } from 'react';
 
 export default function App() {
-  const [authenticated, setAuthenticated] = useState(true);
+  const [authenticated, setAuthenticated] = useState(false);
 
   const app = getApp();
   const firebaseConfig = app ? app.options : undefined;
 
-  // Comment out PhoneAuth AFTER 'yarn run start' to avoid Firebase error
   return (
     <KeyboardAwareScrollView contentContainerStyle={styles.scrollContainer}>
       <View style={styles.container}>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -5,10 +5,12 @@ import { auth } from '../mobile/firebase/firebaseConfig.js';
 import PhoneAuth from './components/PhoneAuth';
 import DataEntry from './components/DataEntry';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import { useState } from 'react';
 
 export default function App() {
-  const app = getApp();
+  const [authenticated, setAuthenticated] = useState(true);
 
+  const app = getApp();
   const firebaseConfig = app ? app.options : undefined;
 
   // Comment out PhoneAuth AFTER 'yarn run start' to avoid Firebase error
@@ -16,7 +18,7 @@ export default function App() {
     <KeyboardAwareScrollView contentContainerStyle={styles.scrollContainer}>
       <View style={styles.container}>
         <StatusBar style="auto" />
-        {/* <PhoneAuth config={firebaseConfig} auth={auth} /> */}
+        <PhoneAuth config={firebaseConfig} auth={auth} authenticated={authenticated} />
         <DataEntry />
       </View >
     </KeyboardAwareScrollView>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,11 +11,12 @@ export default function App() {
 
   const firebaseConfig = app ? app.options : undefined;
 
+  // Comment out PhoneAuth AFTER 'yarn run start' to avoid Firebase error
   return (
     <KeyboardAwareScrollView contentContainerStyle={styles.scrollContainer}>
       <View style={styles.container}>
         <StatusBar style="auto" />
-        <PhoneAuth config={firebaseConfig} auth={auth} />
+        {/* <PhoneAuth config={firebaseConfig} auth={auth} /> */}
         <DataEntry />
       </View >
     </KeyboardAwareScrollView>
@@ -24,7 +25,7 @@ export default function App() {
 
 const styles = StyleSheet.create({
   scrollContainer: {
-    flex: 1,
+    flexGrow: 1,
     backgroundColor: '#fef4e1',
     alignItems: 'center',
     justifyContent: 'center'

--- a/mobile/components/CustomButton.tsx
+++ b/mobile/components/CustomButton.tsx
@@ -15,7 +15,7 @@ import { StyleSheet, Text, Pressable, Alert } from 'react-native';
 
 type ButtonProps = {
   text: string,
-  handleClick: () => {},
+  handleClick: () => object,
   css: object,
 }
 

--- a/mobile/components/DataEntry.tsx
+++ b/mobile/components/DataEntry.tsx
@@ -128,23 +128,19 @@ const DataEntry = () => {
               try {
                 if (!date.trim()) {
                   alert('Please Enter Date');
-                  return;
                 } else if (dateIsValid(date) === false) {
                   alert('Invalid Date' + "\n" + 'Make sure date is MM/DD/YYYY');
-                  return;
                 } else if (!fogNetID.trim()) {
                   alert('Please Enter Fog Net ID');
-                  return;
                 } else if (!clusterID.trim()) {
                   alert('Please Enter Cluster ID');
-                  return;
                 } else if (!fogNetModel.trim()) {
                   alert('Please Enter Model Name');
-                  return;
-                } else if (isNaN(parseFloat(waterCollected))) {
+                } else if (isNaN(parseFloat(waterCollected)) || waterCollected.split('.').length > 2) {
                   alert('Please Enter a Valid Amount of Water Collected');
-                  return;
                 } else if (dateIsValid(date) === true) {
+                  if (waterCollected.slice(-1) === '.')
+                    setWaterCollected(waterCollected + '0')
                   setShowConfirm(true);
                   setEditable(false);
                 }

--- a/mobile/components/DataEntry.tsx
+++ b/mobile/components/DataEntry.tsx
@@ -8,6 +8,8 @@ const DataEntry = () => {
   const [clusterID, setClusterID] = useState("");
   const [fogNetModel, setFogNetModel] = useState("");
   const [waterCollected, setWaterCollected] = useState(0.0);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [editable, setEditable] = useState(true);
 
   // Set placeholder date as today's date
   const currDate = new Date();
@@ -47,72 +49,112 @@ const DataEntry = () => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.promptText}>Date</Text>
-      <TextInput
-        value={date}
-        style={styles.fieldBox}
-        placeholder="MM/DD/YYYY"
-        autoFocus
-        keyboardType="numbers-and-punctuation"
-        onChangeText={date => setDate(date)}
-      />
-      <Text style={styles.promptText}>Fog Net ID</Text>
-      <TextInput
-        style={styles.fieldBox}
-        placeholder="Fog Net ID"
-        onChangeText={fogNetID => setFogNetID(fogNetID)}
-      />
-      <Text style={styles.promptText}>Cluster ID</Text>
-      <TextInput
-        style={styles.fieldBox}
-        placeholder="Cluster ID"
-        onChangeText={clusterID => setClusterID(clusterID)}
-      />
-      <Text style={styles.promptText}>Model Name</Text>
-      <TextInput
-        style={styles.fieldBox}
-        placeholder="Model Name"
-        onChangeText={fogNetModel => setFogNetModel(fogNetModel)}
-      />
-      <Text style={styles.promptText}>Water Collected</Text>
-      <TextInput
-        style={styles.fieldBox}
-        placeholder="0.0"
-        keyboardType="decimal-pad"
-        onChangeText={waterCollected => setWaterCollected(parseFloat(waterCollected))}
-      />
-      <TouchableOpacity style={styles.smallButton}
-        onPress={async () => {
-          try {
-            if (!date.trim()) {
-              alert('Please Enter Date');
-              return;
-            } else if (dateIsValid(date) === false) {
-              alert('Invalid Date' + "\n" + 'Make sure date is MM/DD/YYYY');
-              return;
-            } else if (!fogNetID.trim()) {
-              alert('Please Enter Fog Net ID');
-              return;
-            } else if (!clusterID.trim()) {
-              alert('Please Enter Cluster ID');
-              return;
-            } else if (!fogNetModel.trim()) {
-              alert('Please Enter Model Name');
-              return;
-            } else if (isNaN(waterCollected)) {
-              alert('Please Enter A Valid Amount of Water Collected');
-              return;
-            } else if (dateIsValid(date) === true) {
-              alert("Date: " + parseDate(date) + "\n" + "Fog Net ID: " + fogNetID + "\n"
-                + "Cluster ID: " + clusterID + "\n" + "Model Name: " + fogNetModel
-                + "\n" + "Water Collected: " + waterCollected);
-            }
-          } catch (err) {
-            alert('Please complete all fields');
-          }
-        }}>
-        <Text style={styles.buttonText}>Submit</Text>
-      </TouchableOpacity>
+      {showConfirm ? (
+        <View style={styles.confirmContainer}>
+          <Text style={styles.headerText}>Are you sure this information is correct?</Text>
+          <Text style={[styles.promptText, { padding: 5 }]}>Date: {date}</Text>
+          <Text style={[styles.promptText, { padding: 5 }]}>Fog Net ID #: {fogNetID}</Text>
+          <Text style={[styles.promptText, { padding: 5 }]}>Cluster ID #: {clusterID}</Text>
+          <Text style={[styles.promptText, { padding: 5 }]}>Model Name: {fogNetModel}</Text>
+          <Text style={[styles.promptText, { padding: 5 }]}>Water Collected (L): {waterCollected}</Text>
+          <View style={styles.rowContainer}>
+            <TouchableOpacity style={[styles.confirmButton, { backgroundColor: '#9fd4a3' }]}
+              onPress={async () => {
+                alert("Date: " + parseDate(date) + "\n" + "Fog Net ID: " + fogNetID + "\n"
+                  + "Cluster ID: " + clusterID + "\n" + "Model Name: " + fogNetModel
+                  + "\n" + "Water Collected: " + waterCollected);
+              }}>
+              <Text style={styles.buttonText}>Yes</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.confirmButton, { backgroundColor: '#fe8e86' }]}
+              onPress={async () => {
+                setShowConfirm(false);
+                setEditable(true);
+                setDate(month.toString() + "/" + day.toString() + "/" + year.toString());
+                setFogNetID("");
+                setClusterID("");
+                setFogNetModel("");
+                setWaterCollected(0.0);
+              }}>
+              <Text style={styles.buttonText}>No</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ) : (
+        <View style={styles.container}>
+          <Text style={[styles.headerText, { paddingLeft: 105, paddingRight: 105 }]}>New Entry</Text>
+          <Text style={styles.promptText}>Date:</Text>
+          <TextInput
+            value={date}
+            style={styles.fieldBox}
+            placeholder="MM/DD/YYYY"
+            autoFocus
+            keyboardType="numbers-and-punctuation"
+            onChangeText={date => setDate(date)}
+            editable={editable}
+          />
+          <Text style={styles.promptText}>Fog Net ID #:</Text>
+          <TextInput
+            style={styles.fieldBox}
+            placeholder="Fog Net ID"
+            onChangeText={fogNetID => setFogNetID(fogNetID)}
+            editable={editable}
+          />
+          <Text style={styles.promptText}>Cluster ID #:</Text>
+          <TextInput
+            style={styles.fieldBox}
+            placeholder="Cluster ID"
+            onChangeText={clusterID => setClusterID(clusterID)}
+            editable={editable}
+          />
+          <Text style={styles.promptText}>Model Name:</Text>
+          <TextInput
+            style={styles.fieldBox}
+            placeholder="Model Name"
+            onChangeText={fogNetModel => setFogNetModel(fogNetModel)}
+            editable={editable}
+          />
+          <Text style={styles.promptText}>Water Collected (L):</Text>
+          <TextInput
+            style={styles.fieldBox}
+            placeholder="0.0"
+            keyboardType="decimal-pad"
+            onChangeText={waterCollected => setWaterCollected(parseFloat(waterCollected))}
+            editable={editable}
+          />
+          <TouchableOpacity style={styles.submitButton}
+            onPress={async () => {
+              try {
+                if (!date.trim()) {
+                  alert('Please Enter Date');
+                  return;
+                } else if (dateIsValid(date) === false) {
+                  alert('Invalid Date' + "\n" + 'Make sure date is MM/DD/YYYY');
+                  return;
+                } else if (!fogNetID.trim()) {
+                  alert('Please Enter Fog Net ID');
+                  return;
+                } else if (!clusterID.trim()) {
+                  alert('Please Enter Cluster ID');
+                  return;
+                } else if (!fogNetModel.trim()) {
+                  alert('Please Enter Model Name');
+                  return;
+                } else if (isNaN(waterCollected)) {
+                  alert('Please Enter a Valid Amount of Water Collected');
+                  return;
+                } else if (dateIsValid(date) === true) {
+                  setShowConfirm(true);
+                  setEditable(false);
+                }
+              } catch (err) {
+                alert('Please complete all fields');
+              }
+            }}>
+            <Text style={styles.buttonText}>Submit</Text>
+          </TouchableOpacity>
+        </View>
+      )}
     </View >
   );
 };
@@ -121,28 +163,56 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fef4e1',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    maxWidth: '89%'
   },
-  smallButton: {
+  rowContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    padding: 10
+  },
+  confirmContainer: {
+    flex: 1,
+    backgroundColor: '#fef4e1',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  submitButton: {
     alignItems: 'center',
     borderRadius: 8,
     padding: 10,
     margin: 10,
-    backgroundColor: '#9fd4a3',
-    borderColor: '#f0f0f0'
+    backgroundColor: '#9fd4a3'
+  },
+  confirmButton: {
+    alignItems: 'center',
+    borderRadius: 8,
+    padding: 10,
+    margin: 20,
+    marginLeft: 15,
+    marginRight: 15,
+    flex: 1
+  },
+  headerText: {
+    fontFamily: 'Verdana',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    fontSize: 20,
+    padding: 20
   },
   buttonText: {
     fontFamily: 'Verdana',
-    fontSize: 15,
+    fontSize: 18,
     color: '#ffffff'
   },
   promptText: {
     fontFamily: 'Verdana',
-    fontSize: 15
+    fontWeight: 'bold',
+    fontSize: 17
   },
   fieldBox: {
     marginVertical: 10,
-    fontSize: 17,
+    fontSize: 18,
     padding: 8,
     backgroundColor: "#ffffffff"
   }

--- a/mobile/components/DataEntry.tsx
+++ b/mobile/components/DataEntry.tsx
@@ -7,7 +7,7 @@ const DataEntry = () => {
   const [fogNetID, setFogNetID] = useState("");
   const [clusterID, setClusterID] = useState("");
   const [fogNetModel, setFogNetModel] = useState("");
-  const [waterCollected, setWaterCollected] = useState(0.0);
+  const [waterCollected, setWaterCollected] = useState("");
   const [showConfirm, setShowConfirm] = useState(false);
   const [editable, setEditable] = useState(true);
 
@@ -21,8 +21,10 @@ const DataEntry = () => {
   // Parse input date and convert to Date object
   function parseDate(dateStr: string) {
     const [month, day, year] = dateStr.split('/');
-    const isoFormattedStr = `${year}-${month}-${day}`;
-    const date = new Date(isoFormattedStr);
+    // Note: JS Date object parsing can be unpredictable and is sensitive to
+    // how the string date is formatted (e.g. can be one day off due to time zone)
+    // Passing the parts in as below will ensure Date is hour 0 in the local time zone
+    const date = new Date(parseInt(year), parseInt(month), parseInt(day));
 
     return date
   }
@@ -70,11 +72,6 @@ const DataEntry = () => {
               onPress={async () => {
                 setShowConfirm(false);
                 setEditable(true);
-                setDate(month.toString() + "/" + day.toString() + "/" + year.toString());
-                setFogNetID("");
-                setClusterID("");
-                setFogNetModel("");
-                setWaterCollected(0.0);
               }}>
               <Text style={styles.buttonText}>No</Text>
             </TouchableOpacity>
@@ -95,6 +92,7 @@ const DataEntry = () => {
           />
           <Text style={styles.promptText}>Fog Net ID #:</Text>
           <TextInput
+            value={fogNetID}
             style={styles.fieldBox}
             placeholder="Fog Net ID"
             onChangeText={fogNetID => setFogNetID(fogNetID)}
@@ -102,6 +100,7 @@ const DataEntry = () => {
           />
           <Text style={styles.promptText}>Cluster ID #:</Text>
           <TextInput
+            value={clusterID}
             style={styles.fieldBox}
             placeholder="Cluster ID"
             onChangeText={clusterID => setClusterID(clusterID)}
@@ -109,6 +108,7 @@ const DataEntry = () => {
           />
           <Text style={styles.promptText}>Model Name:</Text>
           <TextInput
+            value={fogNetModel}
             style={styles.fieldBox}
             placeholder="Model Name"
             onChangeText={fogNetModel => setFogNetModel(fogNetModel)}
@@ -116,10 +116,11 @@ const DataEntry = () => {
           />
           <Text style={styles.promptText}>Water Collected (L):</Text>
           <TextInput
+            value={waterCollected}
             style={styles.fieldBox}
             placeholder="0.0"
             keyboardType="decimal-pad"
-            onChangeText={waterCollected => setWaterCollected(parseFloat(waterCollected))}
+            onChangeText={waterCollected => setWaterCollected(waterCollected)}
             editable={editable}
           />
           <TouchableOpacity style={styles.submitButton}
@@ -140,7 +141,7 @@ const DataEntry = () => {
                 } else if (!fogNetModel.trim()) {
                   alert('Please Enter Model Name');
                   return;
-                } else if (isNaN(waterCollected)) {
+                } else if (isNaN(parseFloat(waterCollected))) {
                   alert('Please Enter a Valid Amount of Water Collected');
                   return;
                 } else if (dateIsValid(date) === true) {

--- a/mobile/components/DataEntry.tsx
+++ b/mobile/components/DataEntry.tsx
@@ -8,8 +8,8 @@ const DataEntry = () => {
   const [clusterID, setClusterID] = useState("");
   const [fogNetModel, setFogNetModel] = useState("");
   const [waterCollected, setWaterCollected] = useState("");
-  const [showConfirm, setShowConfirm] = useState(false);
   const [editable, setEditable] = useState(true);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   // Set placeholder date as today's date
   const currDate = new Date();
@@ -54,11 +54,11 @@ const DataEntry = () => {
       {showConfirm ? (
         <View style={styles.confirmContainer}>
           <Text style={styles.headerText}>Are you sure this information is correct?</Text>
-          <Text style={[styles.promptText, { padding: 5 }]}>Date: {date}</Text>
-          <Text style={[styles.promptText, { padding: 5 }]}>Fog Net ID #: {fogNetID}</Text>
-          <Text style={[styles.promptText, { padding: 5 }]}>Cluster ID #: {clusterID}</Text>
-          <Text style={[styles.promptText, { padding: 5 }]}>Model Name: {fogNetModel}</Text>
-          <Text style={[styles.promptText, { padding: 5 }]}>Water Collected (L): {waterCollected}</Text>
+          <Text><Text style={[styles.promptText, { padding: 5 }]}>Date: </Text><Text style={styles.inputText}>{date}</Text></Text>
+          <Text><Text style={[styles.promptText, { padding: 5 }]}>Fog Net ID #: </Text><Text style={styles.inputText}>{fogNetID}</Text></Text>
+          <Text><Text style={[styles.promptText, { padding: 5 }]}>Cluster ID #: </Text><Text style={styles.inputText}>{clusterID}</Text></Text>
+          <Text><Text style={[styles.promptText, { padding: 5 }]}>Model Name: </Text><Text style={styles.inputText}>{fogNetModel}</Text></Text>
+          <Text><Text style={[styles.promptText, { padding: 5 }]}>Water Collected (L): </Text><Text style={styles.inputText}>{waterCollected}</Text></Text>
           <View style={styles.rowContainer}>
             <TouchableOpacity style={[styles.confirmButton, { backgroundColor: '#9fd4a3' }]}
               onPress={async () => {
@@ -141,8 +141,8 @@ const DataEntry = () => {
                 } else if (dateIsValid(date) === true) {
                   if (waterCollected.slice(-1) === '.')
                     setWaterCollected(waterCollected + '0')
-                  setShowConfirm(true);
                   setEditable(false);
+                  setShowConfirm(true);
                 }
               } catch (err) {
                 alert('Please complete all fields');
@@ -178,7 +178,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderRadius: 8,
     padding: 10,
-    margin: 10,
+    margin: 20,
+    marginLeft: 50,
+    marginRight: 50,
     backgroundColor: '#9fd4a3'
   },
   confirmButton: {
@@ -205,6 +207,10 @@ const styles = StyleSheet.create({
   promptText: {
     fontFamily: 'Verdana',
     fontWeight: 'bold',
+    fontSize: 17
+  },
+  inputText: {
+    fontFamily: 'Verdana',
     fontSize: 17
   },
   fieldBox: {

--- a/mobile/components/PhoneAuth.tsx
+++ b/mobile/components/PhoneAuth.tsx
@@ -39,7 +39,7 @@ const PhoneAuth = (props: { config: FirebaseOptions | undefined, auth: any }) =>
               <>
                 <Text style={styles.promptText}>Verify your phone number</Text>
                 <TextInput
-                  style={{ marginVertical: 10, fontSize: 17 }}
+                  style={styles.fieldBox}
                   placeholder="+1 999 999 9999"
                   autoFocus
                   autoComplete="tel"
@@ -77,7 +77,7 @@ const PhoneAuth = (props: { config: FirebaseOptions | undefined, auth: any }) =>
               <>
                 <Text style={styles.promptText}>Enter your OTP</Text>
                 <TextInput
-                  style={{ marginVertical: 10, fontSize: 17 }}
+                  style={styles.fieldBox}
                   placeholder="123456"
                   autoFocus
                   autoComplete="sms-otp"
@@ -139,6 +139,12 @@ const styles = StyleSheet.create({
     fontFamily: 'Verdana',
     fontSize: 15
   },
+  fieldBox: {
+    marginVertical: 10,
+    fontSize: 17,
+    padding: 8,
+    backgroundColor: "#ffffffff"
+  }
 });
 
 export default PhoneAuth;

--- a/mobile/components/PhoneAuth.tsx
+++ b/mobile/components/PhoneAuth.tsx
@@ -8,7 +8,7 @@ import { FirebaseOptions } from 'firebase/app';
  *  @param config is the firebaseConfig
  *  @param auth is the Auth instance associated with the provided Firebase App
 */
-const PhoneAuth = (props: { config: FirebaseOptions | undefined, auth: any }) => {
+const PhoneAuth = (props: { config: FirebaseOptions | undefined, auth: any, authenticated: boolean, }) => {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [otp, setOtp] = useState("");
   const [verificationId, setVerificationId]: any = useState();
@@ -21,7 +21,7 @@ const PhoneAuth = (props: { config: FirebaseOptions | undefined, auth: any }) =>
   const textInput: any = useRef(null);
 
   return (
-    <View style={styles.container}>
+    <View style= {props.authenticated ? styles.container : styles.hidden} >
       <>
         {<FirebaseRecaptchaVerifierModal
           ref={recaptchaVerifier}
@@ -144,6 +144,9 @@ const styles = StyleSheet.create({
     fontSize: 17,
     padding: 8,
     backgroundColor: "#ffffffff"
+  },
+  hidden: {
+    display: 'none'
   }
 });
 


### PR DESCRIPTION
## Overview

Closes: #15  We refactored the data entry component to be styled like the midfis and created a confirmation page for data entry. After pressing Submit on the New Entry page (assuming all fields are filled out), it will bring the user to the Confirmation page.

## Changes Made

We styled the data entry component to look like the midfis and fixed the size of the text inputs so that they do not render off the page when a long user input is given. The confirmation page displays the user inputed data as text (so that it is not editable). Pressing "Yes" will display the data in an alert and pressing "No" will bring the user back to the New Entry page with all the fields cleared (i.e. where all fields are set to their initial states).

## Test Coverage

1) git checkout data-entry-confirmation
2) Make sure PhoneAuth is uncommented when running
3) After running the app, uncomment PhoneAuth
4) Fill in all fields and press submit
5) You should see the confirmation page
6) Pressing "Yes" will show an alert with the data
7) Pressing "No" will bring you back to the New Entry page with all the fields cleared

## Next Steps

We can set a character limit for the data fields if needed. Specifically, for the Water Collected field, if the inputted number is really long, the number will be cut off at around 18 digits on the Confirmation page. This may not be a problem if users will not be inputted numbers that are that long, but it is something to note. Also, if the user accidentally inputs a number with multiple decimal points, the input is still seen as valid, but it will be cut off at the second decimal places on the Confirmation page. For example, "12.34.56" on submit will be "12.34" on the confirmation page. We could prevent this from being a valid input in the first place, but the user is also prompted to confirm their inputs anyway, so that is a decision that we can make.
